### PR TITLE
Upgrade to "include_tasks"

### DIFF
--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -4,12 +4,13 @@ galaxy_info:
   description: Role to docker-host
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: 2.16
 
   platforms:
     - name: Ubuntu
       versions:
         - 22.04
+        - 24.04
 
   galaxy_tags:
     - docker
@@ -17,4 +18,4 @@ galaxy_info:
 dependencies:
   - name: iv.docker-friendly-firewall
     src: https://github.com/IlyaVassyutovich/ansible-role-docker-friendly-firewall
-    version: v/1.0.1
+    version: v/1.1.0

--- a/tasks/configure_docker.yaml
+++ b/tasks/configure_docker.yaml
@@ -1,4 +1,5 @@
 - name: Render daemon.json
+  become: true
   template:
     src: ./daemon.json.j2
     dest: /etc/docker/daemon.json

--- a/tasks/configure_portainer.yaml
+++ b/tasks/configure_portainer.yaml
@@ -1,4 +1,5 @@
 - name: Ensure portainer's directory
+  become: true
   ansible.builtin.file:
     path: "{{ docker.portainer.install_dir }}"
     state: directory
@@ -7,6 +8,7 @@
     mode: "0555"
 
 - name: Render portainer's compose
+  become: true
   ansible.builtin.template:
     src: ./portainer/docker-compose.yaml.j2
     dest: "{{ '/'.join((docker.portainer.install_dir, 'docker-compose.yaml')) }}"
@@ -16,6 +18,7 @@
   notify: Restart portainer
 
 - name: Render portainer's unit file
+  become: true
   ansible.builtin.template:
     src: ./portainer/service.j2
     dest: /etc/systemd/system/portainer.service
@@ -26,11 +29,13 @@
   register: render_portainer_unit
 
 - name: Reload systemd
+  become: true
   ansible.builtin.systemd:
     daemon_reload: true
   when: render_portainer_unit.changed
 
 - name: Enable portainer
+  become: true
   ansible.builtin.service:
     name: portainer.service
     enabled: true

--- a/tasks/enable_start_docker.yaml
+++ b/tasks/enable_start_docker.yaml
@@ -1,4 +1,5 @@
 - name: Enable docker and container.d
+  become: true
   ansible.builtin.service:
     name: "{{ item }}"
     enabled: true

--- a/tasks/install_docker.yaml
+++ b/tasks/install_docker.yaml
@@ -17,6 +17,13 @@
     update_cache: true
   when: apt_repo.changed
 
+  # Need this for CIFS-volumes to work properly with UTF-8
+- name: Setup extra kernel stuff (install)
+  become: true
+  ansible.builtin.apt:
+    name: linux-image-extra-virtual
+    state: present
+
 - name: Setup docker's package (install)
   become: true
   ansible.builtin.apt:

--- a/tasks/install_docker.yaml
+++ b/tasks/install_docker.yaml
@@ -1,20 +1,24 @@
 - name: Setup docker's apt key
+  become: true
   ansible.builtin.apt_key:
     url: "https://download.docker.com/linux/ubuntu/gpg"
     state: present
 
 - name: Setup docker's apt repository
+  become: true
   ansible.builtin.apt_repository:
     repo: "deb [arch={{ deb_architecture[ansible_architecture] }}] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
     state: present
   register: apt_repo
 
 - name: Update apt's cache
+  become: true
   ansible.builtin.apt:
     update_cache: true
   when: apt_repo.changed
 
 - name: Setup docker's package (install)
+  become: true
   ansible.builtin.apt:
     name: "docker-ce={{ docker.version }}"
     state: present
@@ -22,6 +26,7 @@
     - Restart containers infra
 
 - name: Hold docker's packages
+  become: true
   ansible.builtin.dpkg_selections:
     name: "{{ item }}"
     selection: hold

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,22 +1,18 @@
 - name: Prepare facts
-  include: prepare_facts.yaml
+  ansible.builtin.include_tasks: prepare_facts.yaml
   tags: [ portainer ]
 
 - name: Setup/install docker
-  become: true
-  include: install_docker.yaml
+  ansible.builtin.include_tasks: install_docker.yaml
 
 - name: Configure docker
-  become: true
-  include: configure_docker.yaml
+  ansible.builtin.include_tasks: configure_docker.yaml
 
 - name: Enable and start docker
-  become: true
-  include: enable_start_docker.yaml
+  ansible.builtin.include_tasks: enable_start_docker.yaml
 
 - name: Configure portainer
-  become: true
-  include: configure_portainer.yaml
+  ansible.builtin.include_tasks: configure_portainer.yaml
   tags: [ portainer ]
 
 - name: Allow 'me' to use docker


### PR DESCRIPTION
> ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

See also IlyaVassyutovich/ansible-role-docker-friendly-firewall#1